### PR TITLE
when given a shorthand property, consider the value part as the variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,7 +214,11 @@ function registerReference (node) {
 }
 
 function isObjectKey (node) {
-  return node.parent.type === 'Property' && node.parent.key === node
+  return node.parent.type === 'Property' &&
+    node.parent.key === node &&
+    // a shorthand property may have the ===-same node as both the key and the value.
+    // we should detect the value part.
+    node.parent.value !== node
 }
 function isMethodDefinition (node) {
   return node.parent.type === 'MethodDefinition' && node.parent.key === node

--- a/index.js
+++ b/index.js
@@ -43,8 +43,6 @@ function visitBinding (node) {
   assert.ok(typeof node === 'object' && node && typeof node.type === 'string', 'scope-analyzer: visitBinding: node must be an ast node')
   if (isVariable(node)) {
     registerReference(node)
-  } else if (isShorthandProperty(node)) {
-    registerReference(node)
   }
 }
 
@@ -218,18 +216,11 @@ function registerReference (node) {
 function isObjectKey (node) {
   return node.parent.type === 'Property' && node.parent.key === node
 }
-function isObjectValue (node) {
-  return node.parent.type === 'Property' && node.parent.value === node
-}
 function isMethodDefinition (node) {
   return node.parent.type === 'MethodDefinition' && node.parent.key === node
 }
 function isImportName (node) {
   return node.parent.type === 'ImportSpecifier' && node.parent.imported === node
-}
-
-function isShorthandProperty (node) {
-  return node.type === 'Identifier' && isObjectValue(node) && node.parent.shorthand
 }
 
 function isVariable (node) {

--- a/index.js
+++ b/index.js
@@ -218,6 +218,9 @@ function registerReference (node) {
 function isObjectKey (node) {
   return node.parent.type === 'Property' && node.parent.key === node
 }
+function isObjectValue (node) {
+  return node.parent.type === 'Property' && node.parent.value === node
+}
 function isMethodDefinition (node) {
   return node.parent.type === 'MethodDefinition' && node.parent.key === node
 }
@@ -226,7 +229,7 @@ function isImportName (node) {
 }
 
 function isShorthandProperty (node) {
-  return node.type === 'Identifier' && isObjectKey(node) && node.parent.shorthand
+  return node.type === 'Identifier' && isObjectValue(node) && node.parent.shorthand
 }
 
 function isVariable (node) {

--- a/test/index.js
+++ b/test/index.js
@@ -165,6 +165,27 @@ test('references that are declared later', function (t) {
   t.equal(c.getReferences().length, 2, 'should find all references for c')
 })
 
+test('shorthand properties', function (t) {
+  t.plan(3)
+
+  var src = `
+    var b = 1
+    var a = { b }
+    var { c } = a
+    console.log({ c, b, a })
+  `
+  var ast = crawl(src)
+  var body = ast.body
+
+  var scope = scan.scope(ast)
+  var a = scope.getBinding('a')
+  var b = scope.getBinding('b')
+  var c = scope.getBinding('c')
+  t.deepEqual(a.getReferences(), [a.definition, body[2].declarations[0].init, body[3].expression.arguments[0].properties[2].value])
+  t.deepEqual(b.getReferences(), [b.definition, body[1].declarations[0].init.properties[0].value, body[3].expression.arguments[0].properties[1].value])
+  t.deepEqual(c.getReferences(), [c.definition, body[3].expression.arguments[0].properties[0].value])
+})
+
 test('do not count object keys and method definitions as references', function (t) {
   t.plan(2)
 


### PR DESCRIPTION
Hello there!

I was building something cool using your module, and I needed to rename some variables.

In the case of shorthand objects and destructuring declarations, it's a necessity for me to duplicate the key and value nodes, since I don't want to change both of them at the same time. That's when I bumped into an issue: scope-analyzer seems to consider the `key` to be the reference/definition, when in fact it's the `value` side.

I decided to fix this and send a PR with a test.

Thanks for this nice library! I've been enjoying using it.