### PR TITLE
API functions to delete scopes and clear scope analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ binding.getReferences().forEach(function (reference) {
 
 Walk the ast and analyze all scopes. This will immediately allow you to use the `get*` methods on any node in the tree.
 
+### `clear(ast)`
+
+Clear scope information in all nodes of the AST.
+
 ### `visitScope(node)`
 
 Visit a node to check if it initialises any scopes.
@@ -76,6 +80,10 @@ In that case, call `createScope` on the root node with the names of globals:
 var ast = parse('xyz')
 scopeAnalyzer.createScope(ast, ['HTMLElement', 'Notification', ...])
 ```
+
+### `deleteScope(node)`
+
+Delete the scope initialised by node.
 
 ### `scope(node)`
 

--- a/test/index.js
+++ b/test/index.js
@@ -326,3 +326,42 @@ test('initialises a scope for catch clauses', function (t) {
   t.notEqual(scope.getBinding('a'), catchScope.getBinding('a'), 'introduced a different binding')
   t.equal(catchScope.getBinding('a').getReferences().length, 2, 'only counts references to inner `a`')
 })
+
+test('clear all scope information', function (t) {
+  t.plan(6)
+
+  var ast = crawl(`
+    function x() {
+      var y = z
+    }
+    var z = x
+  `)
+
+  var fn = ast.body[0]
+
+  t.ok(scan.scope(ast))
+  t.ok(scan.scope(fn))
+  t.ok(scan.getBinding(fn.id))
+
+  scan.clear(ast)
+
+  t.notOk(scan.scope(ast))
+  t.notOk(scan.scope(fn))
+  t.notOk(scan.getBinding(fn.id))
+})
+
+test('clear partial scope information', function (t) {
+  t.plan(4)
+
+  var ast = crawl('function x() {}')
+
+  var fn = ast.body[0]
+
+  t.ok(scan.scope(fn))
+  t.ok(scan.getBinding(fn.id))
+
+  scan.deleteScope(fn)
+
+  t.notOk(scan.scope(fn))
+  t.ok(scan.getBinding(fn.id))
+})


### PR DESCRIPTION
There are many reasons one could want to delete scope information. In my case, I need to re-calculate the entire scope after performing a bunch of code moves and renames. I could keep track of it all but it's a lot easier to throw everything away and start anew.