### PR TITLE
Handle `ArrowFunctionExpression` nodes

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ function registerScopeBindings (node) {
       })
     })
   }
-  if (node.type === 'FunctionExpression' || node.type === 'ClassExpression') {
+  if (node.type === 'ArrowFunctionExpression' || node.type === 'FunctionExpression' || node.type === 'ClassExpression') {
     var scope = createScope(node)
     if (node.id && node.id.type === 'Identifier') {
       scope.define(new Binding(node.id.name, node.id))


### PR DESCRIPTION
Right now it just ignores the scopes created by arrow functions. This fixes that.

There's another change I also have to apply to my local copy of this module for the analysis I've been working on but I don't know if you'd be interested in it more generally so I'll open another PR for it.