### PR TITLE
Assign "anonymous" values a meaningful id for binding analysis

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,10 @@ exports.getBinding = getBinding
 // create a new scope at a node.
 function createScope (node, bindings) {
   assert.ok(typeof node === 'object' && node && typeof node.type === 'string', 'scope-analyzer: createScope: node must be an ast node')
+  const parentNode = node.parent
+  if (!node.id && parentNode && parentNode.type === 'Property') {
+    node.id = parentNode.key
+  }
   if (!node[kScope]) {
     var parent = getParentScope(node)
     node[kScope] = new Scope(parent)


### PR DESCRIPTION
A lot of values are assigned to named keys with object syntax. For `FunctionExpression`, `ClassExpression` and `ArrowFunctionExpression` types at least, it's super useful to assign property names as identifiers the same way the v8 engine does for stack traces now. This just helps the analyzer to recognize the name bindings that actually exist.